### PR TITLE
Configure log path for scheduled backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Tested on Ubuntu Linux with Ruby 1.9, but should run on any Unix with Ruby.
 See `attributes/default.rb` for default vaules.
 
 * `node['backup']['config_path']` - Where backup configuration data will be stored. Defaults is `/etc/backup`
+* `node['backup']['log_path']` - Where backup logs will be stored. Defaults is `/var/log`
 * `node['backup']['model_path']` - Where backup models (definitions) are stored. Default is `node['backup']['config_path']/models`
 * `node['backup']['dependencies']` - An array of arrays of additional dependencies and optional versions needed for backups. The backup gem will inform you about these when the backup runs. (examples: `['fog']`, `[['fog', '1.4.0'], ['s3']]`)
 * `node['backup']['user']` - User that performs backups. Default is root

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 
 default['backup']['path']         = '/var/backups' # LEGACY
 default['backup']['config_path']  = '/etc/backup'
+default['backup']['log_path']     = '/var/log'
 default['backup']['model_path']   = "#{node['backup']['config_path']}/models"
 default['backup']['dependencies'] = []
 default['backup']['user']         = 'root'

--- a/providers/model.rb
+++ b/providers/model.rb
@@ -2,7 +2,7 @@ action :create do
   file_contents = model_content
 
   cron cron_name do
-    command "backup perform --trigger #{new_resource.name} --config-file #{node['backup']['config_path']}/config.rb --log-path=/var/log"
+    command "backup perform --trigger #{new_resource.name} --config-file #{node['backup']['config_path']}/config.rb --log-path=#{node['backup']['log_path']}"
     user node['backup']['user']
     minute new_resource.schedule[:minute] || '*'
     hour new_resource.schedule[:hour] || '*'


### PR DESCRIPTION
Configure the path for logs generated by backup cron job via the node['backup']['log_path'] attribute.
