### PR TITLE
Use cron LWRP

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,5 @@ license          "Apache 2.0"
 description      "Installs/Configures backup"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.0"
+
+depends          "cron"

--- a/providers/model.rb
+++ b/providers/model.rb
@@ -6,7 +6,7 @@ end
 action :create do
   cron_options = new_resource.cron_options || {}
 
-  cron cron_name do
+  cron_d cron_name do
     command cron_options[:command] ||
       "backup perform --trigger #{new_resource.name} --config-file #{node['backup']['config_path']}/config.rb --log-path=#{node['backup']['log_path']} > /dev/null"
 
@@ -38,7 +38,7 @@ action :create do
 end
 
 action :delete do
-  cron cron_name do
+  cron_d cron_name do
     action :delete
   end
 


### PR DESCRIPTION
why? :
- cleaner - you don't edit crontab file but just add a new file at the right place
- can be updated without updating chef
