### PR TITLE
Fixed path in model provider's delete action

### DIFF
--- a/providers/model.rb
+++ b/providers/model.rb
@@ -43,7 +43,7 @@ action :delete do
   end
 
   file "Model file for #{new_resource.name}" do
-    path model_path
+    path ::File.join(node['backup']['model_path'], "#{new_resource.name}.rb")
     action :delete
   end
 end


### PR DESCRIPTION
This will allow the delete action to work as well as the create action without the model_path method.
