### PR TITLE
Cron schedule in model provider is now optional

### DIFF
--- a/providers/model.rb
+++ b/providers/model.rb
@@ -20,7 +20,7 @@ action :create do
     day new_resource.schedule[:day] || '*'
     month new_resource.schedule[:month] || '*'
     weekday new_resource.schedule[:weekday] || '*'
-  end
+  end unless new_resource.schedule.nil?
 
   template "Model file for #{new_resource.name}" do
     path ::File.join(node['backup']['model_path'], "#{new_resource.name}.rb")


### PR DESCRIPTION
The readme says that setting a cron schedule is optional. This PR will make it so that when no schedule is given cron will not be set.

This is different behavior than previously. Before cron would be set to run every minute.

I thought we could also create a new property in the resource named something like cron_enabled. But I thought this would be more like what would be expected. If people really want to take backups every minute though I could be off base.
