### PR TITLE
Redirect STDERR and STDOUT output of the generated command to the log file if it is specified in cron_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Creates a backup model with an optional `cron` schedule.
 * `description` - A description for the backup. Default is the same as the name.
 * `definition` - A string (best formed as a heredoc) defining the backup. Will be interpoleted and turned into a model file. Required.
 * `schedule` - A hash of times (minute, hour, day, month, weekday) that will be passed to a [`cron` resource](http://docs.opscode.com/chef/resources.html#cron).
-* `cron_options` - A hash of other options to be passed to the `cron` resource. Includes `:command` (will be set to the generated backup command by default), `:mailto`, `:path`, `:shell`, `:user`.
+* `cron_options` - A hash of other options to be passed to the `cron` resource. Includes `:command` (will be set to the generated backup command by default), `:mailto`, `:path`, `:shell`, `:user`. Set `output_log` option to redirect output of the generated backup command  to the log file (by default this output will be ignored).
 
 ### Example
 

--- a/providers/model.rb
+++ b/providers/model.rb
@@ -5,10 +5,18 @@ end
 
 action :create do
   cron_options = new_resource.cron_options || {}
+  cron_output_redirect = if cron_options.key?(:output_log)
+                           "2>&1 >> #{cron_options[:output_log]}"
+                         else
+                           "> /dev/null"
+                         end
 
   cron_d cron_name do
     command cron_options[:command] ||
-      "backup perform --trigger #{new_resource.name} --config-file #{node['backup']['config_path']}/config.rb --log-path=#{node['backup']['log_path']} > /dev/null"
+      "backup perform --trigger #{new_resource.name} \
+      --config-file #{node['backup']['config_path']}/config.rb \
+      --log-path=#{node['backup']['log_path']} \
+      #{cron_output_redirect}".squeeze(' ')
 
     mailto cron_options[:mailto] if cron_options.key?(:mailto)
     path cron_options[:path] if cron_options.key?(:path)


### PR DESCRIPTION
By default the generated command redirects stdout to `/dev/null`. This patch allows to redirect this output to the specified log file - useful for debugging purposes.
