### PR TITLE
Added support for home cron option

### DIFF
--- a/providers/model.rb
+++ b/providers/model.rb
@@ -22,6 +22,7 @@ action :create do
     path cron_options[:path] if cron_options.key?(:path)
     shell cron_options[:shell] if cron_options.key?(:shell)
     user cron_options[:user] || node['backup']['user']
+    home cron_options[:home] if cron_options.key?(:home)
 
     minute new_resource.schedule[:minute] || '*'
     hour new_resource.schedule[:hour] || '*'


### PR DESCRIPTION
Really simple change, home is a valid option for chef's internal cron provider and some people (myself included!) need it.  Tested on CentOS 7 with Backup 4.0.4 and Chef 11.14.6, seems to work fine.
