### PR TITLE
Update mount.rb

### DIFF
--- a/providers/mount.rb
+++ b/providers/mount.rb
@@ -34,8 +34,6 @@ action :disable do
   end
 end
 
-private
-
 def device_name
   "#{node['backup']['server']['address']}:/#{node['backup']['server']['root_path']}/#{new_resource.remote_path}"
 end


### PR DESCRIPTION
On Chef 11.16.4, line #19 fails with this error:

```
NoMethodError: undefined method `device_name' for Chef::Resource::Mount
```

Removing the `private` access modifier makes the method call succeed.

Ruby 2.1.3p242
Ubuntu 12.04
