### PR TITLE
Fix redirect order to output stderr on output_log correctly

### DIFF
--- a/providers/model.rb
+++ b/providers/model.rb
@@ -6,7 +6,7 @@ end
 action :create do
   cron_options = new_resource.cron_options || {}
   cron_output_redirect = if cron_options.key?(:output_log)
-                           "2>&1 >> #{cron_options[:output_log]}"
+                           ">> #{cron_options[:output_log]} 2>&1"
                          else
                            "> /dev/null"
                          end


### PR DESCRIPTION
Original code redirect from stderr to stdout. It does NOT redirect from stderr to file that is specified by cron_options.
Fix redirect order to suppress many mail from cron daemon.
