### PR TITLE
Set non-empty default mount options for the `backup_mount` resource.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@ default['backup']['config_path']  = '/etc/backup'
 default['backup']['log_path']     = '/var/log'
 default['backup']['addl_flags']   = ''
 default['backup']['model_path']   = "#{node['backup']['config_path']}/models"
-default['backup']['mount_options'] = []
+default['backup']['mount_options'] = ['soft', 'nosuid']
 
 default['backup']['user']         = 'root'
 default['backup']['group']        = 'root'


### PR DESCRIPTION
The `backup_mount` resource passes an array of `node['backup']['mount_options']` to the underlying mount resource since #27. Since these mount options are empty by default and they are passed verbatim to the underlying mount resource, not specifying any mount options explicitly results in broken entries in `/etc/fstab`.

For example:
```
root@bib:~# grep nfs /etc/fstab
172.17.17.10://mnt/HD/HD_a2//backups/myserver /data/backups-sync nfs  0 2
172.17.17.10://mnt/HD/HD_a2//backups/myserver /data/backups-sync nfs  0 2
172.17.17.10://mnt/HD/HD_a2//backups/myserver /data/backups-sync nfs  0 2
...
```

Note that each chef-run adds a line to the /etc/fstab file.
When the server restarts, the backup directory will not be mounted until the next chef-run.

This PR adds default, safe options (`default['backup']['mount_options'] = ['soft', 'nosuid']`) which should work out of the box.