### PR TITLE
Fix crash under chef-client 12.5

### DIFF
--- a/resources/model.rb
+++ b/resources/model.rb
@@ -1,7 +1,7 @@
 actions :create, :delete
 default_action :create
 
-attribute :name, :kind_of => Symbol, :name_attribute => true, :required => true
+attribute :name, :kind_of => String, :name_attribute => true, :required => true
 attribute :description, :kind_of => String
 
 attribute :definition, :kind_of => String


### PR DESCRIPTION
chef-client 12.5 doesn't allow name attributes to be Symbols, so change it to be a String
