### PR TITLE
allow to not install gem. it can be already installed via rvm

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,6 +28,7 @@ default['backup']['user']         = 'root'
 default['backup']['group']        = 'root'
 
 default['backup']['dependencies'] = []
+default['backup']['install_gem?'] = true
 default['backup']['version'] = '4.0.2'
 default['backup']['version_from_git?'] = false
 default['backup']['git_repo'] = nil

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,17 +17,19 @@
 # limitations under the License.
 #
 
-if node['backup']['version_from_git?']
-  include_recipe 'gem_specific_install'
-  gem_specific_install "backup" do
-    repository node['backup']['git_repo']
-    revision "master"
-    action :install
-  end
-else
-  gem_package 'backup' do
-    version node['backup']['version'] if node['backup']['version']
-    action :upgrade if node['backup']['upgrade?']
+if node['backup']['install_gem?']
+  if node['backup']['version_from_git?']
+    include_recipe 'gem_specific_install'
+    gem_specific_install "backup" do
+      repository node['backup']['git_repo']
+      revision "master"
+      action :install
+    end
+  else
+    gem_package 'backup' do
+      version node['backup']['version'] if node['backup']['version']
+      action :upgrade if node['backup']['upgrade?']
+    end
   end
 end
 


### PR DESCRIPTION
This cookbook requires system ruby >= 2.0 (gem backup requirement) and does not work for debian with default system ruby (1.9.3) installed.
Because of it I install backup gem via rvm on my servers and that is why it is useful to skip gem installation in this recipe.